### PR TITLE
A rule that notifies the SOC team when an agent is offline for a specified duration

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.5.4-rc.1
+version: 0.5.5-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.5.3-rc.1
+version: 0.5.4-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wazuh/files/configs/rules.overwrite.xml
+++ b/charts/wazuh/files/configs/rules.overwrite.xml
@@ -57,16 +57,6 @@
     <decoded_as>ossec</decoded_as>
     <description>Grouping of wazuh rules.</description>
   </rule>
-
-  <rule id="504" level="10" overwrite="yes">
-    <if_sid>500</if_sid>
-    <match>Agent disconnected</match>
-    <description>Wazuh agent disconnected.</description>
-    <mitre>
-      <id>T1562.001</id>
-    </mitre>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
-  </rule>
   
   <rule id="506" level="0" overwrite="yes">
     <if_sid>500</if_sid>
@@ -115,6 +105,11 @@
     <field name="command">add</field>
     <description>Host Blocked by firewall-drop Active Response</description>
     <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4,</group>
+  </rule>
+
+  <rule id="100501" level="12">
+    <if_sid>504</if_sid>
+    <description>Agent has been offline for more than 7 days (168 hours)</description>
   </rule>
 </group>
 

--- a/charts/wazuh/files/configs/rules.syscheck.xml
+++ b/charts/wazuh/files/configs/rules.syscheck.xml
@@ -1,23 +1,23 @@
 <group name="syscheck,">
-    <rule id="100300" level="0">
+    <rule id="100300" level="5">
         <if_sid>550</if_sid>
         <field name="file">/</field>
         <description>File modified in / directory.</description>
     </rule>
 
-    <rule id="100301" level="0">
+    <rule id="100301" level="5">
         <if_sid>554</if_sid>
         <field name="file">/</field>
         <description>File added to / directory.</description>
     </rule>
 
-    <rule id="100302" level="0">
+    <rule id="100302" level="5">
         <if_sid>550</if_sid>
         <field name="file">C:</field>
         <description>File modified in C:\ directory.</description>
     </rule>
 
-    <rule id="100304" level="0">
+    <rule id="100304" level="5">
         <if_sid>554</if_sid>
         <field name="file">C:</field>
         <description>File added to C:\ directory.</description>

--- a/charts/wazuh/templates/manager/secret.jira-intergration.yaml
+++ b/charts/wazuh/templates/manager/secret.jira-intergration.yaml
@@ -15,7 +15,7 @@ stringData:
            <hook_url>{{ include "common.tplvalues.render" (dict "value" .webhookUrl "context" $) }}</hook_url>
            <api_key>{{ include "common.tplvalues.render" (dict "value" .apikey "context" $) }}</api_key>
            <alert_format>json</alert_format>
-           <level>12</level>
+           <level>14</level>
       </integration>
 
 {{- end -}}


### PR DESCRIPTION
Closes: https://github.com/ADORSYS-GIS/wazuh/issues/235

### Implementation:
Based on the configuration `<agents_disconnection_alert_time>168h</agents_disconnection_alert_time>` in the `ossec.conf` on the manager, is used to set the duration before an alert  will be created based on the agent disconnection status

### Original rule `504` in ` 0015-ossec_rules.xml`:

<img width="1447" height="196" alt="Image" src="https://github.com/user-attachments/assets/c785e6d6-d701-4788-9e2f-a1c42b91f978" />

### Custom rule in `local_rules.xml`:

<img width="753" height="85" alt="Image" src="https://github.com/user-attachments/assets/4faa9513-b14e-43be-97ed-a57ece18ef09" />

### Output:

<img width="712" height="753" alt="Image" src="https://github.com/user-attachments/assets/82f059f7-47b1-4779-887c-1117e130d2af" />
