### PR TITLE
fix: change kubectl repository  to bitnamilegacy

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.5.6-rc.2
+version: 0.5.6-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -118,7 +118,7 @@ secretjob:
     registry: docker.io
     ##
     ##
-    repository: bitnami/kubectl
+    repository: bitnamilegacy/kubectl
     ##
     ##
     tag: latest


### PR DESCRIPTION
### Bitnami Container Images Migration: Using `bitnamilegacy` as a Temporary Measure
Bitnami has moved most of its container images from the `bitnami` repository to `bitnamilegacy`. This affects our deployments that currently rely on bitnami/* images (e.g., bitnami/kubectl).

- The `bitnamilegacy` repository serves as an archive, ensuring workloads don’t immediately break.

However, these images are deprecated and will no longer receive security patches, bug fixes, or updates.

Long-term reliance on `bitnamilegacy` poses a security and stability risk.

**Why use Bitnami Legacy now?**

- Prevents immediate ImagePullBackOff issues.

- Ensures compatibility with existing manifests and Helm charts.

- Provides a temporary safety net while we plan migration.

**Risks**

- No security updates 

- No bug fixes 
REF : https://github.com/bitnami/charts/issues/35164
